### PR TITLE
Fix: Segment Mentors returning duplicate records

### DIFF
--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -72,7 +72,7 @@ export class AppService {
     const query = {
       query: `
         query GetMentorsForSegment($segment_id: bigint, $limit: Int, $offset: Int) {
-          mentor(where: {segmentations: {segment_id: {_eq: $segment_id}}, token: {token: {_is_null: false}}}, limit: $limit, offset: $offset) {
+          mentor(where: {segmentations: {segment_id: {_eq: $segment_id}}, token: {token: {_is_null: false}}}, limit: $limit, offset: $offset, order_by: {id: asc}) {
             phone_no
             officer_name
             token {


### PR DESCRIPTION
Added ordering of mentors by `id: asc` to make sure no duplicate records are returned by the API