### PR TITLE
Add bot deletion logic

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,6 +1,8 @@
-import { Body, Controller, Get, Param, Post, Query, SetMetadata, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Post, Query } from '@nestjs/common';
 import { AppService } from './app.service';
 import { CreateSegmentBotMappingDto } from './dto/CreateSegmentBotMapping.dto';
+import { DeleteSegmentBotMappingDto } from './dto/DeleteSegmentBotMapping.dto';
+
 import { JwtAuthGuard } from './auth/auth-jwt.guard';
 
 export const Roles = (...roles: string[]) => SetMetadata('roles', roles);
@@ -17,6 +19,13 @@ export class AppController {
   @Post('/segment-bot-mapping')
   createSegmentBotMapping(@Body() dto: CreateSegmentBotMappingDto) {
     return this.appService.createSegmentBotMapping(dto);
+  }
+
+  @Roles('OpenRole')
+  @UseGuards(JwtAuthGuard)
+  @Delete('/segment-bot-mapping')
+  deleteSegmentBotMapping(@Query() dto: DeleteSegmentBotMappingDto) {
+    return this.appService.deleteSegmentBotMapping(dto);
   }
 
   @Roles('OpenRole')

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Param, Post, Query } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Post, Query, SetMetadata, UseGuards } from '@nestjs/common';
 import { AppService } from './app.service';
 import { CreateSegmentBotMappingDto } from './dto/CreateSegmentBotMapping.dto';
 import { DeleteSegmentBotMappingDto } from './dto/DeleteSegmentBotMapping.dto';

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { HttpService } from '@nestjs/axios';
 import { lastValueFrom, map } from 'rxjs';
 import { CreateSegmentBotMappingDto } from './dto/CreateSegmentBotMapping.dto';
+import { DeleteSegmentBotMappingDto } from './dto/DeleteSegmentBotMapping.dto';
 
 @Injectable()
 export class AppService {
@@ -63,6 +64,23 @@ export class AppService {
       variables: {
         segment_id: data.segmentId,
         bot_id: data.botId
+      }
+    }
+    return await this.hasuraGraphQLCall(query);
+  }
+
+  async deleteSegmentBotMapping(data: DeleteSegmentBotMappingDto) {
+    const query = {
+      query: `
+      mutation deleteSegmentBots($bot_ids: [uuid!]!) {
+        delete_segment_bots(where : {
+          bot_id:{ _in : $bot_ids}
+        }) {
+         affected_rows
+        }
+    }`,
+      variables: {
+        bot_ids: data.bot_ids
       }
     }
     return await this.hasuraGraphQLCall(query);

--- a/src/dto/DeleteSegmentBotMapping.dto.ts
+++ b/src/dto/DeleteSegmentBotMapping.dto.ts
@@ -1,0 +1,10 @@
+import { Transform, Type } from 'class-transformer';
+import { IsArray, IsString } from 'class-validator';
+
+export class DeleteSegmentBotMappingDto {
+  @IsArray()
+  @IsString({ each: true })
+  @Type(() => String)
+  @Transform(({ value }) => value.split(','))
+  bot_ids?: string[];
+}


### PR DESCRIPTION
Allow UCI to delete bots at our end. Does not delete bot telemetry. Just mapping of bots to segments. 